### PR TITLE
removido imagens sendo carregadas pelo cursor ao se movimentar pelo carrosel.

### DIFF
--- a/sass/home/_card.scss
+++ b/sass/home/_card.scss
@@ -21,6 +21,8 @@
   width: 100%;
   height: auto;
   object-fit: cover;
+
+  pointer-events: none;
 }
 
 .creator-card .heading p {
@@ -86,4 +88,5 @@
   min-height: 280px;
   object-fit: cover;
   object-position: left center;
+  pointer-events: none;
 }


### PR DESCRIPTION
pequena mudança que impede o mouse em ambientes desktop de carregar imagens ao  tentar percorrer o carrosel.